### PR TITLE
Tweak Theme and Styling for #7

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+BROWSER=none

--- a/src/App.css
+++ b/src/App.css
@@ -22,10 +22,6 @@ body {
     grid-template-columns: 1fr;
 }
 
-section#about {
-    width: 75%;
-}
-
 
 /* media query for anything bigger than 1600 */
 @media (min-width: 1600px) {
@@ -38,7 +34,7 @@ section#about {
 /*media query for anything bigger than 1300px*/
 @media (min-width: 1300px) {
     section {
-        width: 100%;
+        width: 75%;
         margin: auto;
         border-radius: 1rem;
     }

--- a/src/App.css
+++ b/src/App.css
@@ -22,6 +22,10 @@ body {
     grid-template-columns: 1fr;
 }
 
+section#contact {
+    width: 100%;
+}
+
 
 /* media query for anything bigger than 1600 */
 @media (min-width: 1600px) {

--- a/src/components/Events/styles.module.css
+++ b/src/components/Events/styles.module.css
@@ -126,8 +126,8 @@
 .event a {
   font-family: Raleway, serif;
   font-size: 1rem;
-  background-color: var(--events-color);
-  color: #fff;
+  background-color: var(--button-primary-color);
+  color: var(--secondary-color);
   padding: 2%;
   font-weight: 400;
   transition: 0.5s;
@@ -138,7 +138,6 @@
   align-content: center;
   line-height: 1.5em;
   margin: 0.16em;
-  border: 1px solid var(--events-color);
   box-shadow: var(--events-color);
   box-sizing: content-box;
   /* disable text selection */
@@ -160,8 +159,8 @@
 .event:hover a {
   color: var(--events-color);
   transition: 0.5s;
-  background-color: #fff;
   padding: 2%;
+  background-color: var(--secondary-color);
 }
 
 .event p {
@@ -213,7 +212,7 @@
 }
 
 .addToCalendarMenu {
-  width: 80%;
+  width: 93%;
   background-color: transparent;
 }
 

--- a/src/components/aboutUs/styles.module.css
+++ b/src/components/aboutUs/styles.module.css
@@ -9,7 +9,6 @@
     display: flex;
     flex-direction: column;
     border-radius: .5rem;
-
 }
 
 .containerHeader {

--- a/src/components/paperTopper/paperTopper.tsx
+++ b/src/components/paperTopper/paperTopper.tsx
@@ -56,7 +56,7 @@ const PaperTopper = (props: PaperTopperProps) => {
                 <h1 className={styles.cardTitle}>ACM San Antonio</h1>
             </div>
             {props.showNote ?
-                <div className={styles.noteContainer} aria-lable={"San Antonio ACM Chapter Logo"}><Logo/> </div> : null
+                <div className={styles.noteContainer} role="banner" aria-label={"San Antonio ACM Chapter Logo"}><Logo/> </div> : null
             }
         </div>
     );

--- a/src/themes.module.css
+++ b/src/themes.module.css
@@ -27,7 +27,7 @@
 /* export colors for bonus-stage theme */
 
 .bonus-stage {
-    --events-color: #ffba49;
+    --events-color: #E79717;
     --background-color: #20a39e;
     --secondary-color: #FFFFFF;
     --about-us-color: #105653;

--- a/src/themes.module.css
+++ b/src/themes.module.css
@@ -33,7 +33,7 @@
     --about-us-color: #105653;
     --link-hover-color: #ffba49;
     --hover-card-color: #e8fcfa;
-    --button-primary-color: #e79717;
+    --button-primary-color: #d1850c;
 }
 
 /* export colors for smooth-sailing theme */


### PR DESCRIPTION
### Issue
Resolves 
- https://github.com/San-Antonio-ACM-Chapter/san-antonio-acm-chapter.github.io/issues/7

### Description
bonus-stage theme with events color and white text is a bit hard to read, 
![image](https://github.com/San-Antonio-ACM-Chapter/san-antonio-acm-chapter.github.io/assets/61089246/f39f5c5e-29bf-4857-b1e6-3be6325ebd3f)
this pr is to make sure new color picked is a bit more readable

### New Updates
- updated `bonus-stage` theme

### Trivial Changes
- changed width of contact section to be full 100%
- update add to button menu style to look a bit better
- added env file to stop a new window/tab from opening each time `npm run start` and ran, 
  - pros: no window spam and having to close the previous localhost 
  - cons: will have to type in url manually on initial load `localhost:3000 `

### Screenshots
![image](https://github.com/San-Antonio-ACM-Chapter/san-antonio-acm-chapter.github.io/assets/61089246/0de0fec4-f923-4d19-abc7-487c3ac2010a)
![image](https://github.com/San-Antonio-ACM-Chapter/san-antonio-acm-chapter.github.io/assets/61089246/d81b1644-0f89-439e-851f-9169d55cf4ee)

### Notes
N/A