### PR TITLE
[FEAT] Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# GitHub Code Owners file
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global Owners
+*       @Geneonosis @Zaqttack


### PR DESCRIPTION
Code Owners are being added to assist in pings and readiness to making updates to the website project! When configured, any code owner can act as an approver and *not all* owners are required for approval. 

Currently, we will require 1 reviewer to have completed the review before anything is merged into main. 